### PR TITLE
add period

### DIFF
--- a/caper/caper_scanner.hpp
+++ b/caper/caper_scanner.hpp
@@ -156,7 +156,7 @@ public:
                     case ']': pop_paren(stack, c); ss << char(c); break;
                     case eof: throw mismatch_paren(addr_, c);
                     default:
-                        if (c == '*' || c == ':' || c == ',' || c == '_' ||
+                        if (c == '*' || c == ':' || c == ',' || c == '_' || c == '.' ||
                             isspace(c)|| isalpha(c)|| isdigit(c)) {
                             ss << char(c);
                             break;


### PR DESCRIPTION
型タグ内でピリオドが書けないと、C#で辛いので許可するようにした。
本来であれば、出力対象言語で切り替えるべきなのだろうが、スキャナーの段階では出力言語を分けてないようだったので、そのまま追加した。